### PR TITLE
css-keyframes-spinner entry

### DIFF
--- a/img/css-keyframes-spinner.svg
+++ b/img/css-keyframes-spinner.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150" viewBox="-75 -75 150 150">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-75 -75 150 150">
 <style>
 @keyframes pulse{40%,60%{opacity:.5}}
 @keyframes spin{

--- a/img/css-keyframes-spinner.svg
+++ b/img/css-keyframes-spinner.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150" viewBox="-75 -75 150 150">
+<style>
+@keyframes pulse{40%,60%{opacity:.5}}
+@keyframes spin{
+0%,10%{transform:rotate(0deg) translate(5px,0) rotate(0deg)}
+30%,40%{transform:rotate(0deg) translate(30px,0) rotate(0deg)}
+60%,70%{transform:rotate(60deg) translate(30px,0) rotate(0deg)}
+90%,100%{transform:rotate(60deg) translate(30px,0) rotate(180deg)}
+}
+@keyframes step-rotate{
+3%,33%{transform:rotate(120deg)}
+37%,67%{transform:rotate(240deg)}
+70%,100%{transform:rotate(360deg)}
+}
+use{animation:pulse 1s infinite linear,spin 5s infinite alternate}
+.loader{animation:step-rotate 15s infinite}
+</style>
+<defs><g id="o">
+<path fill="currentColor" d="M0 0h30v30H0z"/>
+<circle cx="15" cy="15" r="20" fill="none" stroke="currentColor" stroke-width="4"/>
+</g></defs>
+<g class="loader">
+<g color="tomato"><use href="#o"/></g>
+<g transform="rotate(120)" color="#4169e1"><use href="#o"/></g>
+<g transform="rotate(240)" color="#3cb371"><use href="#o"/></g>
+</g>
+</svg>

--- a/js/entries.js
+++ b/js/entries.js
@@ -5,4 +5,5 @@ export default [
   // either a point of contact or a link to a detail explanation of the demo.
   { file: 'clouds.svg', author: "Jérémie Patonnier", link: "https://twitter.com/JeremiePat/" },
   { file: 'svg1k.svg', author: "Jérémie Patonnier", link: "https://twitter.com/JeremiePat/" },
+  { file: 'css-keyframes-spinner.svg', author: "Amelia Bellamy-Royds", link: "https://codepen.io/AmeliaBR/" },
 ]


### PR DESCRIPTION
To get this little loader/spinner SVG it under 1024 bytes, I had to run it through SVGOMG & remove the xlink prefix (and namespace declaration). Still renders fine in modern browsers, of course!

PS, it wasn't clear, but if it should actually be under 1000 bytes, I can re-remove the line breaks. But since we expect people to read the code, I figured they were helpful!